### PR TITLE
chore: github에서 jira 자동화 워크플로 추가 (#57)

### DIFF
--- a/.github/workflows/close-jira-issue-basic.yml
+++ b/.github/workflows/close-jira-issue-basic.yml
@@ -1,0 +1,46 @@
+name: 이슈 종료 시 Jira 상태 전환 및 작업 중 라벨 제거
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  sync-close:
+    name: Jira 상태 완료 처리 및 라벨 제거
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Jira 로그인
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: 이슈 제목에서 Jira 키 추출
+        id: extract
+        run: |
+          TITLE="${{ github.event.issue.title }}"
+          JIRA_KEY=$(echo "$TITLE" | grep -oE '\[[A-Z]+-[0-9]+\]' | head -n1 | tr -d '[]')
+
+          if [ -n "$JIRA_KEY" ]; then
+            echo "✅ Jira 키: $JIRA_KEY"
+            echo "jira_key=$JIRA_KEY" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Jira 키를 이슈 제목에서 찾을 수 없습니다."
+            exit 1
+          fi
+
+      - name: Jira 태스크 상태를 완료로 변경
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ steps.extract.outputs.jira_key }}
+          transition: 완료
+
+      - name: GitHub 이슈에서 "🛠 작업 중" 라벨 제거
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'remove-labels'
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: '🛠 작업 중'

--- a/.github/workflows/close-jira-issue-basic.yml
+++ b/.github/workflows/close-jira-issue-basic.yml
@@ -19,8 +19,10 @@ jobs:
 
       - name: 이슈 제목에서 Jira 키 추출
         id: extract
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
-          TITLE="${{ github.event.issue.title }}"
+          TITLE="$ISSUE_TITLE"
           JIRA_KEY=$(echo "$TITLE" | grep -oE '\[[A-Z]+-[0-9]+\]' | head -n1 | tr -d '[]')
 
           if [ -n "$JIRA_KEY" ]; then

--- a/.github/workflows/create-jira-issue-basic.yml
+++ b/.github/workflows/create-jira-issue-basic.yml
@@ -58,7 +58,7 @@ jobs:
                 "key": "${{ steps.issue-parser.outputs.issueparser_parentKey }}"
               }
             }
-      
+
       # 앞서 지라에서 생성한 티켓 넘버로 feat/{티켓넘버} 형식의 브랜치 생성
       - name: 브랜치 생성
         run: |
@@ -87,3 +87,11 @@ jobs:
           body: |
             🧾 **Jira에도 태스크가 생성되었습니다🌟**  
             🔗 [${{ steps.create.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create.outputs.issue }})
+
+      - name: GitHub 이슈에 "🛠 작업 중" 라벨 추가
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'add-labels'
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: '🛠 작업 중'


### PR DESCRIPTION
## #️⃣연관된 이슈

#57 

## 📝작업 내용

### `create-jira-issue-basic.yml`
- github에서 티켓 넘버가 포함된 브랜치에 커밋이 발생할 시 gihub 이슈 라벨에 "작업중" 추가
- jira에서 해당 태스크 진행중 표시

### `close-jira-issue-basic.yml`
- github에서 이슈를 완료 처리할 시 "작업중" 라벨 삭제
- jira에서 해당 태스크 완료 표시