### PR TITLE
style: tailwind 커스텀 컬러 추가

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
     files: ["**/*.{js,jsx,ts,tsx}"],
+    ignores: ["tailwind.config.cjs"],
     plugins: {
       "@typescript-eslint": typescriptEslintPlugin,
       "prettier": eslintPluginPrettier,

--- a/src/app/common/AppHeaderBottomBar.tsx
+++ b/src/app/common/AppHeaderBottomBar.tsx
@@ -5,7 +5,7 @@ export default function AppHeaderBottomBar({
 }) {
 	return (
 		<div
-			className={`absolute left-1/2 transform -translate-x-1/2 -bottom-2.5 h-0.5 w-16 bg-[color:var(--color-ossca-mint-300)] transition-opacity duration-300 ${
+			className={`absolute left-1/2 transform -translate-x-1/2 -bottom-2.5 h-0.5 w-16 bg-ossca-mint-300 transition-opacity duration-300 ${
 				isVisible ? 'opacity-100' : 'opacity-0'
 			}`}
 		/>

--- a/src/app/common/DropDownButton.tsx
+++ b/src/app/common/DropDownButton.tsx
@@ -86,7 +86,7 @@ export default function DropDownButton({
 							currentPath === item.href ? (
 								<span
 									key={item.href}
-									className="grid place-items-center block w-full py-2 text-sm pretendard-700 bg-[color:var(--color-ossca-mint-300)] cursor-text"
+									className="grid place-items-center w-full py-2 text-sm pretendard-700 bg-ossca-mint-300 cursor-text"
 									role="menuitem"
 								>
 									{item.label}
@@ -96,7 +96,7 @@ export default function DropDownButton({
 									key={item.href}
 									href={item.href}
 									onClick={() => setActiveDropdownId(null)}
-									className="grid place-items-center block w-full py-2 text-sm pretendard-500 hover:bg-gray-100"
+									className="grid place-items-center w-full py-2 text-sm pretendard-500 hover:bg-gray-100"
 									role="menuitem"
 								>
 									{item.label}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,7 +1,10 @@
+/* eslint-disable */
 // tailwind.config.js
+const lineClamp = require('@tailwindcss/line-clamp');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-	content: ['./app/**/*.{js,ts,jsx,tsx,mdx}'],
+	content: ['./src/app/**/*.{js,ts,jsx,tsx,mdx}'],
 	theme: {
 		extend: {
 			colors: {
@@ -20,5 +23,5 @@ module.exports = {
 			},
 		},
 	},
-	plugins: [import('@tailwindcss/line-clamp').default],
+	plugins: [lineClamp],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,24 @@
+// tailwind.config.js
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+	content: ['./app/**/*.{js,ts,jsx,tsx,mdx}'],
+	theme: {
+		extend: {
+			colors: {
+				'ossca-mint': {
+					100: 'oklch(0.95 0.0489 180.52)',
+					200: 'oklch(0.93 0.055 180.67)',
+					300: 'oklch(0.89 0.1663 172.72)',
+					400: 'oklch(0.69 0.1314 173.3407)',
+					500: 'oklch(0.72 0.1308 174.9)',
+					600: 'oklch(0.715 0.142 178.7)',
+				},
+				'ossca-gray': {
+					100: 'oklch(0.89 0 0)',
+					200: 'oklch(0.82 0.0036 174.46)',
+				},
+			},
+		},
+	},
+	plugins: [import('@tailwindcss/line-clamp').default],
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

#32 

## 📝작업 내용

### `tailwind.config.js` 수정
- globals.css에 정의된 커스텀 색상을 tailwind.config.js에 추가했습니다.
- 클래스에서 `bg-ossca-mint-100` 형태로 사용 가능합니다.
- 편의를 위해 vscode 익스텐션 중 하나인 [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) 사용을 추천 드립니다.
- 해당 익스텐션을 사용하면 아래 사진과 같이 컬러를 코드 내에서 미리 보고 바로 사용할 수 있습니다.
<img src="https://github.com/user-attachments/assets/1c47d7b9-6e82-4e6d-9640-f56cfe047036" width="400" />

### `AppHeader` 관련 컴포넌트 수정
- tailwind 유틸리티로 교체하여 사용했습니다.

## 참고

구분 | globals.css에서의 `@theme` 방식 | tailwind.config.js 방식
--------- | ------------ | ------------
사용 형태 | [color:var(--color-name)] 형태 | text-color-name 형태
타입 안전성 | CSS 변수명 오타 시 런타임 에러 | 빌드 타임에 검증 가능
재사용성 | CSS 변수로 다양한 속성에 사용 가능 | Tailwind 유틸리티로 제한
유지보수 | CSS 파일에서 관리 | JavaScript 설정 파일에서 관리
