### PR TITLE
refactor: 포스팅 상세 페이지 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"next-mdx-remote": "^5.0.0",
 				"react": "^19.0.0",
 				"react-dom": "^19.0.0",
+				"rehype-sanitize": "^6.0.0",
 				"remark": "^15.0.1",
 				"remark-breaks": "^4.0.0",
 				"remark-gfm": "^4.0.1",
@@ -7221,6 +7222,20 @@
 				"@types/estree": "^1.0.0",
 				"@types/hast": "^3.0.0",
 				"hast-util-to-estree": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-sanitize": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+			"integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-sanitize": "^5.0.0"
 			},
 			"funding": {
 				"type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"next-mdx-remote": "^5.0.0",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
+		"rehype-sanitize": "^6.0.0",
 		"remark": "^15.0.1",
 		"remark-breaks": "^4.0.0",
 		"remark-gfm": "^4.0.1",

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -97,6 +97,25 @@ async function getDetailPost(slug: string) {
 	};
 }
 
+function PostTitle({ title, slug }: { title?: string; slug: string }) {
+	return (
+		<div className="w-[90%] mx-auto">
+			<h1 className="text-3xl font-bold mb-6">{title || slug} TIL</h1>
+		</div>
+	);
+}
+
+function PostContent({ children }: { children: React.ReactNode }) {
+	return (
+		<div
+			className="w-[90%] px-7 py-7 mb-2 mx-auto rounded-xl"
+			style={{ backgroundColor: 'rgba(206, 206, 206, 0.2)' }}
+		>
+			<article className="prose prose-lg dark:prose-invert">{children}</article>
+		</div>
+	);
+}
+
 export default async function PostingDetailPage({ params }: Props) {
 	const { slug } = await params;
 
@@ -105,20 +124,8 @@ export default async function PostingDetailPage({ params }: Props) {
 
 	return (
 		<div className="mx-auto mt-2">
-			{/* 제목 */}
-			<div className="w-[90%] mx-auto">
-				<h1 className="text-3xl font-bold mb-6">{post.title || slug} TIL</h1>
-			</div>
-
-			{/* 본문 카드 */}
-			<div
-				className="w-[90%] px-7 py-7 mb-2 mx-auto rounded-xl"
-				style={{ backgroundColor: 'rgba(206, 206, 206, 0.2)' }}
-			>
-				<article className="prose prose-lg dark:prose-invert">
-					{post.mdxElement}
-				</article>
-			</div>
+			<PostTitle title={post.title} slug={slug} />
+			<PostContent>{post.mdxElement}</PostContent>
 		</div>
 	);
 }

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -15,12 +15,43 @@ interface Props {
 	params: Promise<Params>;
 }
 
+function requireToken() {
+	const env = {
+		GITHUB_OWNER: process.env.GITHUB_OWNER,
+		GITHUB_REPO: process.env.GITHUB_REPO,
+		GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+	};
+
+	const missing = Object.entries(env)
+		.filter(([, v]) => !v || v.trim() === '')
+		.map(([k]) => k);
+
+	if (missing.length) {
+		throw new Error(
+			`환경 변수 설정 오류: ${missing.join(', ')} 누락되었습니다.`,
+		);
+	}
+
+	const {
+		GITHUB_OWNER: owner,
+		GITHUB_REPO: repo,
+		GITHUB_TOKEN: token,
+	} = env as {
+		GITHUB_OWNER: string;
+		GITHUB_REPO: string;
+		GITHUB_TOKEN: string;
+	};
+
+	return { owner, repo, token };
+}
+
 // GitHub API로부터 MD 파일 내용(base64) 가져오기
 async function getMarkdownContent(slug: string) {
+	const { owner, repo, token } = requireToken();
 	const res = await fetch(
-		`https://api.github.com/repos/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}/contents/til/${slug}.md`,
+		`https://api.github.com/repos/${owner}/${repo}/contents/til/${slug}.md`,
 		{
-			headers: { Authorization: `token ${process.env.GITHUB_TOKEN}` },
+			headers: { Authorization: `token ${token}` },
 			cache: 'no-cache',
 		},
 	);

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -10,10 +10,10 @@ interface Params {
 	slug: string;
 }
 
-type Props = {
+interface Props {
 	// Next.js 15에서는 params가 Promise로 넘어옴
 	params: Promise<Params>;
-};
+}
 
 // GitHub API로부터 MD 파일 내용(base64) 가져오기
 async function getMarkdownContent(slug: string) {

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -68,7 +68,7 @@ async function getDetailPost(slug: string) {
 	if (!markdown) return null;
 
 	const { content, data } = matter(markdown);
-	const normalizedContent = content;
+	const normalizedContent = content.replace(/<br>/g, '<br />');
 
 	const { content: mdxElement } = await compileMDX({
 		source: normalizedContent,

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -1,5 +1,3 @@
-// src/app/posting/[slug]/page.tsx
-
 import { compileMDX } from 'next-mdx-remote/rsc';
 import matter from 'gray-matter';
 import remarkGfm from 'remark-gfm';
@@ -10,12 +8,13 @@ import { notFound } from 'next/navigation';
 interface Params {
 	slug: string;
 }
-
 interface Props {
-	// Next.js 15에서는 params가 Promise로 넘어옴
 	params: Promise<Params>;
 }
 
+/**
+ * Github 환경 변수 체크
+ */
 function requireGitEnv() {
 	const env = {
 		GITHUB_OWNER: process.env.GITHUB_OWNER,
@@ -28,7 +27,6 @@ function requireGitEnv() {
 			`환경 변수 설정 오류: ${missing.join(', ')} 누락되었습니다.`,
 		);
 	}
-
 	const {
 		GITHUB_OWNER: owner,
 		GITHUB_REPO: repo,
@@ -43,7 +41,7 @@ function requireGitEnv() {
 }
 
 /**
- * 깃허브 API가 반환하는 Base64 형태의 파일을 utf-8로 반환
+ * Github API가 반환하는 Base64 형태의 파일을 utf-8로 반환
  */
 async function getMarkdownContent(slug: string) {
 	const { owner, repo, token } = requireGitEnv();
@@ -63,6 +61,9 @@ async function getMarkdownContent(slug: string) {
 	return markdown;
 }
 
+/**
+ * 특정 포스트(slug) 내용 mdx 형태로 가져오기
+ */
 async function getDetailPost(slug: string) {
 	const markdown = await getMarkdownContent(slug);
 	if (!markdown) return null;

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -55,7 +55,10 @@ async function getMarkdownContent(slug: string) {
 			cache: 'no-cache',
 		},
 	);
-	if (!res.ok) return null;
+	if (res.status === 404) return null;
+	if (!res.ok) {
+		throw new Error(`markdown fetching 오류: ${res.status} ${res.statusText}`);
+	}
 	const { content } = await res.json();
 	return Buffer.from(content, 'base64').toString('utf-8');
 }

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -62,7 +62,8 @@ async function getMarkdownContent(slug: string) {
 		throw new Error(`markdown fetching 오류: ${res.status} ${res.statusText}`);
 	}
 	const { content } = await res.json();
-	return Buffer.from(content, 'base64').toString('utf-8');
+	const markdown = Buffer.from(content, 'base64').toString('utf-8');
+	return markdown;
 }
 
 export default async function PostingDetailPage({ params }: Props) {

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -68,9 +68,16 @@ async function getDetailPost(slug: string) {
 	if (!markdown) return null;
 
 	const { content, data } = matter(markdown);
+
 	const normalizedContent = content
+		// HTML 태그 (br, img) self-closing 처리
 		.replace(/<br>/g, '<br />')
-		.replace(/<img([^>]*?)(?<!\/)>/gi, '<img$1 />');
+		.replace(/<img([^>]*?)(?<!\/)>/gi, '<img$1 />')
+
+		// 링크 안의 꺾쇠괄호 이스케이프 처리
+		.replace(/\[([^\]]*)<([^>]*>)/g, (_, before, after) => {
+			return `[${before}&lt;${after.replace('>', '&gt;')}`;
+		});
 
 	const { content: mdxElement } = await compileMDX({
 		source: normalizedContent,

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -16,7 +16,7 @@ interface Props {
  * Github 환경 변수 체크
  */
 function requireGitEnv() {
-	const env = {
+        const GitEnv = {
 		GITHUB_OWNER: process.env.GITHUB_OWNER,
 		GITHUB_REPO: process.env.GITHUB_REPO,
 		GITHUB_TOKEN: process.env.GITHUB_TOKEN,

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -46,17 +46,17 @@ function requireGitEnv() {
  */
 async function getMarkdownContent(slug: string) {
 	const { owner, repo, token } = requireGitEnv();
-	const res = await fetch(
-		`https://api.github.com/repos/${owner}/${repo}/contents/til/${slug}.md`,
-		{
-			headers: { Authorization: `token ${token}` },
-			cache: 'no-cache',
-		},
-	);
+
+	const repoUrl = `https://api.github.com/repos/${owner}/${repo}/contents/til/${slug}.md`;
+	const res = await fetch(repoUrl, {
+		headers: { Authorization: `token ${token}` },
+		cache: 'no-cache',
+	});
 	if (res.status === 404) return null;
 	if (!res.ok) {
 		throw new Error(`markdown fetching 오류: ${res.status} ${res.statusText}`);
 	}
+
 	const { content } = await res.json();
 	const markdown = Buffer.from(content, 'base64').toString('utf-8');
 	return markdown;

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -3,6 +3,7 @@
 import { compileMDX } from 'next-mdx-remote/rsc';
 import matter from 'gray-matter';
 import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
 import { MdxStyle } from '../components/MdxStyle';
 import { notFound } from 'next/navigation';
 
@@ -73,49 +74,15 @@ export default async function PostingDetailPage({ params }: Props) {
 	// frontmatter(meta) 분리
 	const { content, data } = matter(markdown);
 
-	// HTML 태그가 아닌 모든 '<', '>'를 이스케이프
-	const escapeNonHtmlTags = (markdown: string) => {
-		let escaped = markdown
-			.split('\n')
-			.map((line) => {
-				if (/^\s*>/.test(line)) {
-					// 인용구 라인은 그대로
-					return line;
-				}
-				return line
-					.replace(/<(?!\/?\w+[^>]*>)/g, '&lt;')
-					.replace(/(?<!<[^>]+)>(?![^<]*>)/g, '&gt;');
-			})
-			.join('\n');
+	const normalizedContent = content;
 
-		// 링크 텍스트 내 '<', '>' 이스케이프
-		escaped = escaped.replace(
-			/\[([^\]]*?<[^>]+>[^\]]*?)\]\((.*?)\)/g,
-			(_, linkText, url) =>
-				`[${linkText.replace(/</g, '&lt;').replace(/>/g, '&gt;')}](${url})`,
-		);
-
-		// 모든 URL 텍스트를 자동 링크로 변환
-		escaped = escaped.replace(
-			/(?<!\]\()(?<!\]:\s*)(?<!["'=\(])\b(https?:\/\/[^\s<>\[\](){}"']+)/g,
-			(url) => `[${url}](${url})`,
-		);
-
-		return escaped;
-	};
-
-	// self-closing 태그 보정
-	const normalizedContent = escapeNonHtmlTags(content)
-		.replace(/<br>/g, '<br />')
-		.replace(/<img([^>]*)(?<!\/)>/g, '<img$1 />');
-
-	// MDX → React Element
 	const { content: mdxElement } = await compileMDX({
 		source: normalizedContent,
 		options: {
 			parseFrontmatter: false,
 			mdxOptions: {
-				remarkPlugins: [remarkGfm], // GFM 테이블 지원
+				remarkPlugins: [remarkGfm],
+				rehypePlugins: [rehypeSanitize],
 			},
 		},
 		components: MdxStyle,

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -16,12 +16,12 @@ interface Props {
  * Github 환경 변수 체크
  */
 function requireGitEnv() {
-        const GitEnv = {
+	const GitEnv = {
 		GITHUB_OWNER: process.env.GITHUB_OWNER,
 		GITHUB_REPO: process.env.GITHUB_REPO,
 		GITHUB_TOKEN: process.env.GITHUB_TOKEN,
 	};
-	const missing = Object.entries(env).filter(([, v]) => !v?.trim());
+	const missing = Object.entries(GitEnv).filter(([, v]) => !v?.trim());
 	if (missing.length) {
 		throw new Error(
 			`환경 변수 설정 오류: ${missing.join(', ')} 누락되었습니다.`,
@@ -31,7 +31,7 @@ function requireGitEnv() {
 		GITHUB_OWNER: owner,
 		GITHUB_REPO: repo,
 		GITHUB_TOKEN: token,
-	} = env as {
+	} = GitEnv as {
 		GITHUB_OWNER: string;
 		GITHUB_REPO: string;
 		GITHUB_TOKEN: string;

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -63,17 +63,11 @@ async function getMarkdownContent(slug: string) {
 	return markdown;
 }
 
-export default async function PostingDetailPage({ params }: Props) {
-	// params가 Promise이므로 await로 풀어야 slug에 접근할 수 있음
-	const { slug } = await params;
-
-	// GitHub에서 MD 파일 내용 가져오기
+async function getDetailPost(slug: string) {
 	const markdown = await getMarkdownContent(slug);
-	if (!markdown) return notFound();
+	if (!markdown) return null;
 
-	// frontmatter(meta) 분리
 	const { content, data } = matter(markdown);
-
 	const normalizedContent = content;
 
 	const { content: mdxElement } = await compileMDX({
@@ -88,11 +82,23 @@ export default async function PostingDetailPage({ params }: Props) {
 		components: MdxStyle,
 	});
 
+	return {
+		title: data.title as string | undefined,
+		mdxElement,
+	};
+}
+
+export default async function PostingDetailPage({ params }: Props) {
+	const { slug } = await params;
+
+	const post = await getDetailPost(slug);
+	if (!post) return notFound();
+
 	return (
 		<div className="mx-auto mt-2">
 			{/* 제목 */}
 			<div className="w-[90%] mx-auto">
-				<h1 className="text-3xl font-bold mb-6">{data.title || slug} TIL</h1>
+				<h1 className="text-3xl font-bold mb-6">{post.title || slug} TIL</h1>
 			</div>
 
 			{/* 본문 카드 */}
@@ -101,7 +107,7 @@ export default async function PostingDetailPage({ params }: Props) {
 				style={{ backgroundColor: 'rgba(206, 206, 206, 0.2)' }}
 			>
 				<article className="prose prose-lg dark:prose-invert">
-					{mdxElement}
+					{post.mdxElement}
 				</article>
 			</div>
 		</div>

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -4,61 +4,13 @@ import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import { MdxStyle } from '../components/MdxStyle';
 import { notFound } from 'next/navigation';
+import { getMarkdownContent } from '../../../lib/github';
 
 interface Params {
 	slug: string;
 }
 interface Props {
 	params: Promise<Params>;
-}
-
-/**
- * Github 환경 변수 체크
- */
-function requireGitEnv() {
-	const GitEnv = {
-		GITHUB_OWNER: process.env.GITHUB_OWNER,
-		GITHUB_REPO: process.env.GITHUB_REPO,
-		GITHUB_TOKEN: process.env.GITHUB_TOKEN,
-	};
-	const missing = Object.entries(GitEnv).filter(([, v]) => !v?.trim());
-	if (missing.length) {
-		throw new Error(
-			`환경 변수 설정 오류: ${missing.join(', ')} 누락되었습니다.`,
-		);
-	}
-	const {
-		GITHUB_OWNER: owner,
-		GITHUB_REPO: repo,
-		GITHUB_TOKEN: token,
-	} = GitEnv as {
-		GITHUB_OWNER: string;
-		GITHUB_REPO: string;
-		GITHUB_TOKEN: string;
-	};
-
-	return { owner, repo, token };
-}
-
-/**
- * Github API가 반환하는 Base64 형태의 파일을 utf-8로 반환
- */
-async function getMarkdownContent(slug: string) {
-	const { owner, repo, token } = requireGitEnv();
-
-	const repoUrl = `https://api.github.com/repos/${owner}/${repo}/contents/til/${slug}.md`;
-	const res = await fetch(repoUrl, {
-		headers: { Authorization: `token ${token}` },
-		cache: 'no-cache',
-	});
-	if (res.status === 404) return null;
-	if (!res.ok) {
-		throw new Error(`markdown fetching 오류: ${res.status} ${res.statusText}`);
-	}
-
-	const { content } = await res.json();
-	const markdown = Buffer.from(content, 'base64').toString('utf-8');
-	return markdown;
 }
 
 /**

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -68,7 +68,9 @@ async function getDetailPost(slug: string) {
 	if (!markdown) return null;
 
 	const { content, data } = matter(markdown);
-	const normalizedContent = content.replace(/<br>/g, '<br />');
+	const normalizedContent = content
+		.replace(/<br>/g, '<br />')
+		.replace(/<img([^>]*?)(?<!\/)>/gi, '<img$1 />');
 
 	const { content: mdxElement } = await compileMDX({
 		source: normalizedContent,

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -45,7 +45,9 @@ function requireToken() {
 	return { owner, repo, token };
 }
 
-// GitHub API로부터 MD 파일 내용(base64) 가져오기
+/**
+ * 깃허브 API가 반환하는 Base64 형태의 파일을 utf-8로 반환
+ */
 async function getMarkdownContent(slug: string) {
 	const { owner, repo, token } = requireToken();
 	const res = await fetch(

--- a/src/app/posting/[slug]/page.tsx
+++ b/src/app/posting/[slug]/page.tsx
@@ -15,17 +15,13 @@ interface Props {
 	params: Promise<Params>;
 }
 
-function requireToken() {
+function requireGitEnv() {
 	const env = {
 		GITHUB_OWNER: process.env.GITHUB_OWNER,
 		GITHUB_REPO: process.env.GITHUB_REPO,
 		GITHUB_TOKEN: process.env.GITHUB_TOKEN,
 	};
-
-	const missing = Object.entries(env)
-		.filter(([, v]) => !v || v.trim() === '')
-		.map(([k]) => k);
-
+	const missing = Object.entries(env).filter(([, v]) => !v?.trim());
 	if (missing.length) {
 		throw new Error(
 			`환경 변수 설정 오류: ${missing.join(', ')} 누락되었습니다.`,
@@ -49,7 +45,7 @@ function requireToken() {
  * 깃허브 API가 반환하는 Base64 형태의 파일을 utf-8로 반환
  */
 async function getMarkdownContent(slug: string) {
-	const { owner, repo, token } = requireToken();
+	const { owner, repo, token } = requireGitEnv();
 	const res = await fetch(
 		`https://api.github.com/repos/${owner}/${repo}/contents/til/${slug}.md`,
 		{

--- a/src/app/posting/components/PostingList.tsx
+++ b/src/app/posting/components/PostingList.tsx
@@ -3,12 +3,12 @@
 import { useMemo, useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import Divider from '../common/Divider';
-import SearchBar from '../common/SearchBar';
-import SortArticle, { SortType } from '../common/SortArticle';
-import SearchResultCount from '../search/SearchResultCount';
-import ArticleSnippet from './components/ArticleSnippet';
-import NotFound from './components/NotFound';
+import Divider from '../../common/Divider';
+import SearchBar from '../../common/SearchBar';
+import SortArticle, { SortType } from '../../common/SortArticle';
+import SearchResultCount from '../../search/SearchResultCount';
+import ArticleSnippet from './ArticleSnippet';
+import NotFound from './NotFound';
 import TabMenu from '@/app/common/TabMenu';
 
 interface Post {
@@ -22,10 +22,7 @@ interface Props {
 	searchKeyword: string; // 빈 문자열이면 검색 모드 아님
 }
 
-export default function PostingTemplate({
-	filteredPosts,
-	searchKeyword,
-}: Props) {
+export default function PostingList({ filteredPosts, searchKeyword }: Props) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 

--- a/src/app/posting/components/PostingList.tsx
+++ b/src/app/posting/components/PostingList.tsx
@@ -1,170 +1,24 @@
 'use client';
-
-import { useMemo, useState, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
-import Divider from '../../common/Divider';
-import SearchBar from '../../common/SearchBar';
-import SortArticle, { SortType } from '../../common/SortArticle';
-import SearchResultCount from '../../search/SearchResultCount';
-import ArticleSnippet from './ArticleSnippet';
-import NotFound from './NotFound';
-import TabMenu from '@/app/common/TabMenu';
+import { SearchView } from '@/app/search/components/SearchView';
+import { TabView } from './TabView';
 
 interface Post {
 	slug: string;
 	title: string;
 	subHeadings: string[];
 }
-
 interface Props {
 	filteredPosts: Post[];
-	searchKeyword: string; // 빈 문자열이면 검색 모드 아님
+	searchKeyword?: string;
 }
 
 export default function PostingList({ filteredPosts, searchKeyword }: Props) {
-	const router = useRouter();
-	const searchParams = useSearchParams();
-
 	const isSearchMode = Boolean(searchKeyword);
-
-	// 검색 모드: SortArticle + 검색 결과
-	const [sortType, setSortType] = useState<SortType>('latest');
-	const sortedPosts = useMemo(() => {
-		if (sortType === 'latest' || !searchKeyword) {
-			// 검색 전이거나 최신순 선택 시 그냥 원본 배열
-			return filteredPosts;
-		}
-		// 정확도순 정렬 로직
-		const score = (post: Post) => {
-			const q = searchKeyword.toLowerCase();
-			const inTitle = post.title.toLowerCase().includes(q) ? 2 : 0;
-			const inSubs = post.subHeadings.filter((sh) =>
-				sh.toLowerCase().includes(q),
-			).length;
-			return inTitle + inSubs;
-		};
-		return [...filteredPosts].sort((a, b) => score(b) - score(a));
-	}, [filteredPosts, searchKeyword, sortType]);
-
-	// 탭 모드: normalPosts
-	const normalPosts = filteredPosts.filter((p) => /^\d{4}$/.test(p.slug));
-
-	// tabs 생성
-	const tabs = useMemo(
-		() =>
-			Array.from(new Set(normalPosts.map((p) => p.slug.slice(0, 2)))).sort(
-				(a, b) => Number(b) - Number(a),
-			),
-		[normalPosts],
-	);
-
-	// URL ?tab= 읽어서 탭 동기화
-	const urlTab = searchParams.get('tab') ?? '';
-	const defaultTab = tabs[0] ?? '';
-	const [activeTab, setActiveTab] = useState<string>(urlTab || defaultTab);
-
-	// URL이 바뀔 때(activeTab이 달라질 때) state 업데이트
-	useEffect(() => {
-		if (isSearchMode) return; // 검색 모드면 아무것도 안 함
-		if (urlTab && tabs.includes(urlTab)) {
-			setActiveTab(urlTab);
-		} else {
-			// query가 없거나 유효하지 않으면 기본 탭으로
-			setActiveTab(defaultTab);
-			router.replace(`?tab=${defaultTab}`);
-		}
-	}, [urlTab, tabs, defaultTab, router, isSearchMode]);
-
-	// 탭 클릭 핸들러
-	const onTabClick = (tab: string) => {
-		if (tab === activeTab) return;
-		setActiveTab(tab);
-		router.push(`?tab=${tab}`);
-	};
-
-	// 해당 탭 포스트 필터
-	const postsForTab = useMemo(
-		() => normalPosts.filter((p) => p.slug.startsWith(activeTab)),
-		[normalPosts, activeTab],
-	);
-
-	// 검색 결과 개수
-	const count = sortedPosts.length;
-
-	// ─── 렌더링 분기 ───────────────────────────
 	if (isSearchMode) {
-		if (filteredPosts.length === 0) {
-			return (
-				<div className="mt-10">
-					<SearchBar />
-					<Divider
-						className="mb-8 mx-auto"
-						width="w-9/10"
-						color="border-ossca-gray-100"
-					/>
-					<NotFound />
-				</div>
-			);
-		}
-
-		// 검색 모드 UI
 		return (
-			<div className="mt-10">
-				<SearchBar />
-				<Divider
-					className="mb-8 mx-auto"
-					width="w-9/10"
-					color="border-ossca-gray-100"
-				/>
-
-				<div className="ml-[5%] mb-10">
-					<SearchResultCount count={count} />
-					<SortArticle sortType={sortType} onChange={setSortType} />
-				</div>
-
-				{sortedPosts.length > 0 ? (
-					sortedPosts.map((post) => (
-						<Link href={`/posting/${post.slug}`} key={post.slug}>
-							<ArticleSnippet
-								title={post.title}
-								subHeadings={post.subHeadings}
-							/>
-						</Link>
-					))
-				) : (
-					<NotFound />
-				)}
-			</div>
+			<SearchView filteredPosts={filteredPosts} searchKeyword={searchKeyword} />
 		);
 	}
 
-	return (
-		<div className="mt-2">
-			{/* 탭 + 검색창 (90% 컨테이너) */}
-			<div className="w-9/10 mx-auto flex items-center justify-between h-[48px] mb-6">
-				<TabMenu tabs={tabs} activeTab={activeTab} setActiveTab={onTabClick} />
-				<div className="w-[350px] [&>div]:!mb-0 [&>div]:!ml-0 [&>div>div]:w-full">
-					<SearchBar />
-				</div>
-			</div>
-
-			{/* 구분선 */}
-			<Divider
-				className="mb-8 mx-auto"
-				width="w-9/10"
-				color="border-ossca-gray-100"
-			/>
-
-			{postsForTab.length > 0 ? (
-				postsForTab.map((p) => (
-					<Link href={`/posting/${p.slug}`} key={p.slug}>
-						<ArticleSnippet title={p.title} subHeadings={p.subHeadings} />
-					</Link>
-				))
-			) : (
-				<NotFound />
-			)}
-		</div>
-	);
+	return <TabView filteredPosts={filteredPosts} />;
 }

--- a/src/app/posting/components/TabView.tsx
+++ b/src/app/posting/components/TabView.tsx
@@ -1,0 +1,45 @@
+import { useTabState } from '../hooks/useTabState';
+import TabMenu from '../../common/TabMenu';
+import SearchBar from '../../common/SearchBar';
+import Divider from '../../common/Divider';
+import NotFound from './NotFound';
+import ArticleSnippet from './ArticleSnippet';
+import Link from 'next/link';
+
+interface Post {
+	slug: string;
+	title: string;
+	subHeadings: string[];
+}
+
+function TabView({ filteredPosts }: { filteredPosts: Post[] }) {
+	const normalPosts = filteredPosts.filter((p) => /^\d{4}$/.test(p.slug));
+	const { tabs, activeTab, onTabClick, postsForTab } = useTabState(normalPosts);
+
+	return (
+		<div className="mt-2">
+			<div className="w-9/10 mx-auto flex items-center justify-between h-[48px] mb-6">
+				<TabMenu tabs={tabs} activeTab={activeTab} setActiveTab={onTabClick} />
+				<div className="w-[350px] [&>div]:!mb-0 [&>div]:!ml-0 [&>div>div]:w-full">
+					<SearchBar />
+				</div>
+			</div>
+			<Divider
+				className="mb-8 mx-auto"
+				width="w-9/10"
+				color="border-ossca-gray-100"
+			/>
+			{postsForTab.length > 0 ? (
+				postsForTab.map((p) => (
+					<Link href={`/posting/${p.slug}`} key={p.slug}>
+						<ArticleSnippet title={p.title} subHeadings={p.subHeadings} />
+					</Link>
+				))
+			) : (
+				<NotFound />
+			)}
+		</div>
+	);
+}
+
+export { TabView };

--- a/src/app/posting/hooks/useSortedPosts.tsx
+++ b/src/app/posting/hooks/useSortedPosts.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { SortType } from '@/app/common/SortArticle';
+import { useMemo } from 'react';
+
+interface Post {
+	slug: string;
+	title: string;
+	subHeadings: string[];
+}
+
+function useSortedPosts(
+	posts: Post[],
+	keyword: string | undefined,
+	sortType: SortType,
+) {
+	return useMemo(() => {
+		if (sortType === 'latest' || !keyword) return posts;
+		const q = keyword.toLowerCase();
+		const score = (post: Post) => {
+			const inTitle = post.title.toLowerCase().includes(q) ? 2 : 0;
+			const inSubs = post.subHeadings.filter((sh) =>
+				sh.toLowerCase().includes(q),
+			).length;
+			return inTitle + inSubs;
+		};
+		return [...posts].sort((a, b) => score(b) - score(a));
+	}, [posts, keyword, sortType]);
+}
+
+export { useSortedPosts };

--- a/src/app/posting/hooks/useTabState.tsx
+++ b/src/app/posting/hooks/useTabState.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useMemo, useState, useEffect } from 'react';
+
+interface Post {
+	slug: string;
+	title: string;
+	subHeadings: string[];
+}
+
+function useTabState(normalPosts: Post[]) {
+	const router = useRouter();
+	const searchParams = useSearchParams();
+
+	const tabs = useMemo(
+		() =>
+			Array.from(new Set(normalPosts.map((p) => p.slug.slice(0, 2)))).sort(
+				(a, b) => Number(b) - Number(a),
+			),
+		[normalPosts],
+	);
+
+	const urlTab = searchParams.get('tab') ?? '';
+	const defaultTab = tabs[0] ?? '';
+	const [activeTab, setActiveTab] = useState<string>(urlTab || defaultTab);
+
+	useEffect(() => {
+		if (urlTab && tabs.includes(urlTab)) {
+			setActiveTab(urlTab);
+		} else {
+			setActiveTab(defaultTab);
+			router.replace(`?tab=${defaultTab}`);
+		}
+	}, [urlTab, tabs, defaultTab, router]);
+
+	const onTabClick = (tab: string) => {
+		if (tab === activeTab) return;
+		setActiveTab(tab);
+		router.push(`?tab=${tab}`);
+	};
+
+	const postsForTab = useMemo(
+		() => normalPosts.filter((p) => p.slug.startsWith(activeTab)),
+		[normalPosts, activeTab],
+	);
+
+	return { tabs, activeTab, onTabClick, postsForTab };
+}
+
+export { useTabState };

--- a/src/app/posting/page.tsx
+++ b/src/app/posting/page.tsx
@@ -9,21 +9,17 @@ function extractSubHeadings(markdown: string) {
 		.map((line) => line.replace(/^##\s+/, '').trim());
 }
 
-// 포스트 타입
 interface Post {
 	slug: string;
 	title: string;
 	subHeadings: string[];
 }
 
-// ✔️ Next.js 15에선 searchParams 가 Promise 로 들어올 수 있음
 interface Props {
 	searchParams?: Promise<{ q?: string }>;
 }
 
-//포스팅 페이지 컴포넌트(GitHub에서 Markdown 목록 가져오고, 각 파일의 내용 파싱하여 게시글 리스트로 렌더링)
 export default async function PostingPage({ searchParams }: Props) {
-	// ✔️ 먼저 resolve 해서 동기 값으로 변환
 	const resolvedParams = searchParams ? await searchParams : undefined;
 	const searchKeyword = resolvedParams?.q?.toLowerCase() || '';
 

--- a/src/app/posting/page.tsx
+++ b/src/app/posting/page.tsx
@@ -1,5 +1,5 @@
 import matter from 'gray-matter'; // Markdown 파일의 frontmatter(meta 정보)를 파싱하기 위한 라이브러리
-import PostingTemplate from './PostingTemplate';
+import PostingList from './components/PostingList';
 const GITHUB_API_URL = 'https://api.github.com';
 
 // GitHub 저장소에서 TIL 디렉토리 내의 Markdown 파일 목록을 가져오는 함수
@@ -104,9 +104,6 @@ export default async function PostingPage({ searchParams }: Props) {
 	const filteredPosts = posts.filter((post): post is Post => post !== null); // null 제거
 
 	return (
-		<PostingTemplate
-			filteredPosts={filteredPosts}
-			searchKeyword={searchKeyword}
-		/>
+		<PostingList filteredPosts={filteredPosts} searchKeyword={searchKeyword} />
 	);
 }

--- a/src/app/posting/page.tsx
+++ b/src/app/posting/page.tsx
@@ -1,6 +1,6 @@
 import matter from 'gray-matter'; // Markdown 파일의 frontmatter(meta 정보)를 파싱하기 위한 라이브러리
 import PostingList from './components/PostingList';
-import { getMarkdownList, getMarkdownContent } from '../../lib/github';
+import { getMarkdownList, getMarkdownContentByUrl } from '../../lib/github';
 
 function extractSubHeadings(markdown: string) {
 	return markdown
@@ -27,10 +27,10 @@ export default async function PostingPage({ searchParams }: Props) {
 
 	const posts = await Promise.all(
 		files
-			.filter((file) => file.name.endsWith('.md')) // .md 파일만 필터링
+			.filter((file: { name: string }) => file.name.endsWith('.md')) // .md 파일만 필터링
 			.reverse() // 최신 순으로 정렬
-			.map(async (file) => {
-				const content = await getMarkdownContent(file.url); // 내용 가져오기
+			.map(async (file: { name: string; url: string }) => {
+				const content = await getMarkdownContentByUrl(file.url);
 				if (!content) return null; // null인 경우 필터될 수 있게 처리
 				const { data } = matter(content); // frontmatter 파싱
 				const subHeadings = extractSubHeadings(content); // Subheading 추출

--- a/src/app/posting/page.tsx
+++ b/src/app/posting/page.tsx
@@ -1,51 +1,13 @@
 import matter from 'gray-matter'; // Markdown 파일의 frontmatter(meta 정보)를 파싱하기 위한 라이브러리
 import PostingList from './components/PostingList';
-const GITHUB_API_URL = 'https://api.github.com';
+import { getMarkdownList, getMarkdownContent } from '../../lib/github';
 
-// GitHub 저장소에서 TIL 디렉토리 내의 Markdown 파일 목록을 가져오는 함수
-const getMarkdownList = async (): Promise<
-	{
-		name: string;
-		url: string;
-	}[]
-> => {
-	const res = await fetch(
-		`${GITHUB_API_URL}/repos/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}/contents/til`,
-		{
-			headers: {
-				Authorization: `token ${process.env.GITHUB_TOKEN}`, // GitHub 인증 토큰
-			},
-			next: { revalidate: 60 }, // ISR 위한 설정 (60초마다 재검증)
-		},
-	);
-
-	if (!res.ok) throw new Error('GitHub 파일 목록 가져오기 실패');
-	return res.json();
-};
-
-// 특정 Markdown 파일의 원본 content를 GitHub API로부터 가져오고 base64 디코딩하여 반환하는 함수
-const getMarkdownContent = async (url: string): Promise<string | null> => {
-	const res = await fetch(url, {
-		headers: {
-			Authorization: `token ${process.env.GITHUB_TOKEN}`,
-		},
-	});
-
-	if (!res.ok) throw new Error('파일 내용 가져오기 실패');
-
-	const fileData: { content: string } = await res.json();
-	const decoded = Buffer.from(fileData.content, 'base64').toString('utf-8'); // Base64 디코딩
-
-	return decoded.trim() === '' ? null : decoded; // 사전 필터: 내용이 비어있으면 null 반환
-};
-
-// Markdown 본문에서 '## ' 로 시작하는 Subheading들만 추출하여 배열로 반환하는 함수
-const extractSubHeadings = (markdown: string): string[] => {
-	const lines = markdown.split('\n');
-	return lines
-		.filter((line) => line.startsWith('## ')) // Subheading만 필터링
-		.map((line) => line.replace(/^##\s+/, '').trim()); // '## ' 제거 후 공백 제거
-};
+function extractSubHeadings(markdown: string) {
+	return markdown
+		.split('\n')
+		.filter((line) => line.startsWith('## '))
+		.map((line) => line.replace(/^##\s+/, '').trim());
+}
 
 // 포스트 타입
 interface Post {

--- a/src/app/search/components/SearchResultCount.tsx
+++ b/src/app/search/components/SearchResultCount.tsx
@@ -1,9 +1,13 @@
-export default function SearchResultCount() {
-	const count = 3;
+interface Props {
+	count: number;
+}
 
+function SearchResultCount({ count }: Props) {
 	return (
 		<div className="w-[120] pl-1 pr-1 text-center mt-3 pt-2 pb-2 rounded-[0.3vw] font-bold text-xl text-white bg-ossca-mint-300/80">
 			{count} Results
 		</div>
 	);
 }
+
+export { SearchResultCount };

--- a/src/app/search/components/SearchView.tsx
+++ b/src/app/search/components/SearchView.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { useState } from 'react';
+import Link from 'next/link';
+import SearchBar from '../../common/SearchBar';
+import Divider from '../../common/Divider';
+import NotFound from '../../posting/components/NotFound';
+import { SearchResultCount } from './SearchResultCount';
+import SortArticle from '../../common/SortArticle';
+import ArticleSnippet from '../../posting/components/ArticleSnippet';
+import { SortType } from '@/app/common/SortArticle';
+import { useSortedPosts } from '../../posting/hooks/useSortedPosts';
+
+interface Post {
+	slug: string;
+	title: string;
+	subHeadings: string[];
+}
+
+interface Props {
+	filteredPosts: Post[];
+	searchKeyword?: string;
+}
+
+function SearchView({ filteredPosts, searchKeyword }: Props) {
+	const [sortType, setSortType] = useState<SortType>('latest');
+	const sortedPosts = useSortedPosts(filteredPosts, searchKeyword, sortType);
+	const count = sortedPosts.length;
+
+	if (filteredPosts.length === 0) {
+		return (
+			<div className="mt-10">
+				<SearchBar />
+				<Divider
+					className="mb-8 mx-auto"
+					width="w-9/10"
+					color="border-ossca-gray-100"
+				/>
+				<NotFound />
+			</div>
+		);
+	}
+
+	return (
+		<div className="mt-10">
+			<SearchBar />
+			<Divider
+				className="mb-8 mx-auto"
+				width="w-9/10"
+				color="border-ossca-gray-100"
+			/>
+			<div className="ml-[5%] mb-10">
+				<SearchResultCount count={count} />
+				<SortArticle sortType={sortType} onChange={setSortType} />
+			</div>
+			{sortedPosts.length > 0 ? (
+				sortedPosts.map((post) => (
+					<Link href={`/posting/${post.slug}`} key={post.slug}>
+						<ArticleSnippet title={post.title} subHeadings={post.subHeadings} />
+					</Link>
+				))
+			) : (
+				<NotFound />
+			)}
+		</div>
+	);
+}
+
+export { SearchView };

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,25 +1,28 @@
+const GITHUB_ENV_KEYS = [
+	'GITHUB_OWNER',
+	'GITHUB_REPO',
+	'GITHUB_TOKEN',
+] as const;
+
 function requireGitEnv() {
-	const GitEnv = {
-		GITHUB_OWNER: process.env.GITHUB_OWNER,
-		GITHUB_REPO: process.env.GITHUB_REPO,
-		GITHUB_TOKEN: process.env.GITHUB_TOKEN,
-	};
-	const missing = Object.entries(GitEnv).filter(([, v]) => !v?.trim());
-	if (missing.length) {
+	const env: Partial<Record<(typeof GITHUB_ENV_KEYS)[number], string>> = {};
+	for (const key of GITHUB_ENV_KEYS) {
+		const value = process.env[key]?.trim();
+		if (value) {
+			env[key] = value;
+		}
+	}
+	const missingKeys = GITHUB_ENV_KEYS.filter((key) => !env[key]);
+	if (missingKeys.length > 0) {
 		throw new Error(
-			`환경 변수 설정 오류: ${missing.join(', ')} 누락되었습니다.`,
+			`환경 변수 설정 오류: ${missingKeys.join(', ')} 누락되었습니다.`,
 		);
 	}
-	const {
-		GITHUB_OWNER: owner,
-		GITHUB_REPO: repo,
-		GITHUB_TOKEN: token,
-	} = GitEnv as {
-		GITHUB_OWNER: string;
-		GITHUB_REPO: string;
-		GITHUB_TOKEN: string;
+	return {
+		owner: env.GITHUB_OWNER as string,
+		repo: env.GITHUB_REPO as string,
+		token: env.GITHUB_TOKEN as string,
 	};
-	return { owner, repo, token };
 }
 
 async function getMarkdownList() {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,6 +1,3 @@
-/**
- * Github 환경 변수 체크
- */
 function requireGitEnv() {
 	const GitEnv = {
 		GITHUB_OWNER: process.env.GITHUB_OWNER,
@@ -22,28 +19,34 @@ function requireGitEnv() {
 		GITHUB_REPO: string;
 		GITHUB_TOKEN: string;
 	};
-
 	return { owner, repo, token };
 }
 
-/**
- * Github API가 반환하는 Base64 형태의 파일을 utf-8로 반환
- */
+async function getMarkdownList() {
+	const { owner, repo, token } = requireGitEnv();
+	const res = await fetch(
+		`https://api.github.com/repos/${owner}/${repo}/contents/til`,
+		{
+			headers: { Authorization: `token ${token}` },
+			next: { revalidate: 60 },
+		},
+	);
+	if (!res.ok) throw new Error('GitHub 파일 목록 가져오기 실패');
+	return res.json();
+}
+
 async function getMarkdownContent(slug: string) {
 	const { owner, repo, token } = requireGitEnv();
-
 	const repoUrl = `https://api.github.com/repos/${owner}/${repo}/contents/til/${slug}.md`;
 	const res = await fetch(repoUrl, {
 		headers: { Authorization: `token ${token}` },
 		cache: 'no-cache',
 	});
 	if (res.status === 404) return null;
-	if (!res.ok) {
+	if (!res.ok)
 		throw new Error(`markdown fetching 오류: ${res.status} ${res.statusText}`);
-	}
 	const { content } = await res.json();
-	const markdown = Buffer.from(content, 'base64').toString('utf-8');
-	return markdown;
+	return Buffer.from(content, 'base64').toString('utf-8');
 }
 
-export { requireGitEnv, getMarkdownContent };
+export { requireGitEnv, getMarkdownList, getMarkdownContent };

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -39,7 +39,9 @@ async function getMarkdownList() {
 		headers: createAuthHeaders(token),
 		next: { revalidate: 60 },
 	});
-	if (!res.ok) throw new Error('GitHub 파일 목록 가져오기 실패');
+	if (res.status === 404) return null;
+	if (!res.ok)
+		throw new Error(`markdown list fetching 오류: ${res.status} ${res.status}`);
 	return res.json();
 }
 
@@ -52,7 +54,9 @@ async function getMarkdownContent(slug: string) {
 	});
 	if (res.status === 404) return null;
 	if (!res.ok)
-		throw new Error(`markdown fetching 오류: ${res.status} ${res.statusText}`);
+		throw new Error(
+			`markdown content fetching 오류: ${res.status} ${res.statusText}`,
+		);
 	const { content } = await res.json();
 	return Buffer.from(content, 'base64').toString('utf-8');
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -61,4 +61,26 @@ async function getMarkdownContent(slug: string) {
 	return Buffer.from(content, 'base64').toString('utf-8');
 }
 
-export { requireGitEnv, getMarkdownList, getMarkdownContent };
+async function getMarkdownContentByUrl(url: string): Promise<string | null> {
+	const { token } = requireGitEnv();
+	const cleanUrl = url.split('?')[0];
+	const res = await fetch(cleanUrl, {
+		headers: createAuthHeaders(token),
+	});
+	if (res.status === 404) return null;
+	if (!res.ok) {
+		throw new Error(
+			`markdown content fetching 오류: ${res.status} ${res.statusText}`,
+		);
+	}
+	const { content } = await res.json();
+	const decoded = Buffer.from(content, 'base64').toString('utf-8');
+	return decoded.trim() === '' ? null : decoded;
+}
+
+export {
+	requireGitEnv,
+	getMarkdownList,
+	getMarkdownContent,
+	getMarkdownContentByUrl,
+};

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -3,6 +3,7 @@ const GITHUB_ENV_KEYS = [
 	'GITHUB_REPO',
 	'GITHUB_TOKEN',
 ] as const;
+const GITHUB_API_BASE_URL = 'https://api.github.com/repos';
 
 function requireGitEnv() {
 	const env: Partial<Record<(typeof GITHUB_ENV_KEYS)[number], string>> = {};
@@ -28,7 +29,7 @@ function requireGitEnv() {
 async function getMarkdownList() {
 	const { owner, repo, token } = requireGitEnv();
 	const res = await fetch(
-		`https://api.github.com/repos/${owner}/${repo}/contents/til`,
+		`${GITHUB_API_BASE_URL}/${owner}/${repo}/contents/til`,
 		{
 			headers: { Authorization: `token ${token}` },
 			next: { revalidate: 60 },
@@ -40,7 +41,7 @@ async function getMarkdownList() {
 
 async function getMarkdownContent(slug: string) {
 	const { owner, repo, token } = requireGitEnv();
-	const repoUrl = `https://api.github.com/repos/${owner}/${repo}/contents/til/${slug}.md`;
+	const repoUrl = `${GITHUB_API_BASE_URL}/${owner}/${repo}/contents/til/${slug}.md`;
 	const res = await fetch(repoUrl, {
 		headers: { Authorization: `token ${token}` },
 		cache: 'no-cache',

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,35 +1,49 @@
-// src/lib/github.ts
-// GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO 는 .env 로 관리
-const TOKEN = process.env.GITHUB_TOKEN;
-const OWNER = process.env.GITHUB_OWNER;
-const REPO = process.env.GITHUB_REPO;
+/**
+ * Github 환경 변수 체크
+ */
+function requireGitEnv() {
+	const GitEnv = {
+		GITHUB_OWNER: process.env.GITHUB_OWNER,
+		GITHUB_REPO: process.env.GITHUB_REPO,
+		GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+	};
+	const missing = Object.entries(GitEnv).filter(([, v]) => !v?.trim());
+	if (missing.length) {
+		throw new Error(
+			`환경 변수 설정 오류: ${missing.join(', ')} 누락되었습니다.`,
+		);
+	}
+	const {
+		GITHUB_OWNER: owner,
+		GITHUB_REPO: repo,
+		GITHUB_TOKEN: token,
+	} = GitEnv as {
+		GITHUB_OWNER: string;
+		GITHUB_REPO: string;
+		GITHUB_TOKEN: string;
+	};
 
-// GitHub API를 호출해 til 디렉토리 내 .md 파일 목록만 반환
-export async function fetchMdFileList() {
-	const url = `https://api.github.com/repos/${OWNER}/${REPO}/contents/til`;
-
-	const res = await fetch(url, {
-		headers: {
-			Authorization: `Bearer ${TOKEN}`,
-			Accept: 'application/vnd.github.v3+json',
-		},
-	});
-
-	if (!res.ok) throw new Error('파일 목록 로딩 실패');
-	const data = (await res.json()) as Array<{ name: string; url: string }>;
-	return data.filter((item) => item.name.endsWith('.md'));
+	return { owner, repo, token };
 }
 
-// GitHub raw 컨텐츠로부터 텍스트를 가져오는 함수
-export async function fetchMdFileContent(filename: string) {
-	const url = `https://raw.githubusercontent.com/${OWNER}/${REPO}/main/til/${filename}`;
+/**
+ * Github API가 반환하는 Base64 형태의 파일을 utf-8로 반환
+ */
+async function getMarkdownContent(slug: string) {
+	const { owner, repo, token } = requireGitEnv();
 
-	const res = await fetch(url, {
-		headers: {
-			Authorization: `Bearer ${TOKEN}`,
-		},
+	const repoUrl = `https://api.github.com/repos/${owner}/${repo}/contents/til/${slug}.md`;
+	const res = await fetch(repoUrl, {
+		headers: { Authorization: `token ${token}` },
+		cache: 'no-cache',
 	});
-
-	if (!res.ok) throw new Error('파일 내용 로딩 실패');
-	return await res.text();
+	if (res.status === 404) return null;
+	if (!res.ok) {
+		throw new Error(`markdown fetching 오류: ${res.status} ${res.statusText}`);
+	}
+	const { content } = await res.json();
+	const markdown = Buffer.from(content, 'base64').toString('utf-8');
+	return markdown;
 }
+
+export { requireGitEnv, getMarkdownContent };

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -26,24 +26,28 @@ function requireGitEnv() {
 	};
 }
 
+function createAuthHeaders(token: string) {
+	return {
+		Authorization: `token ${token}`,
+	};
+}
+
 async function getMarkdownList() {
 	const { owner, repo, token } = requireGitEnv();
-	const res = await fetch(
-		`${GITHUB_API_BASE_URL}/${owner}/${repo}/contents/til`,
-		{
-			headers: { Authorization: `token ${token}` },
-			next: { revalidate: 60 },
-		},
-	);
+	const url = `${GITHUB_API_BASE_URL}/${owner}/${repo}/contents/til`;
+	const res = await fetch(url, {
+		headers: createAuthHeaders(token),
+		next: { revalidate: 60 },
+	});
 	if (!res.ok) throw new Error('GitHub 파일 목록 가져오기 실패');
 	return res.json();
 }
 
 async function getMarkdownContent(slug: string) {
 	const { owner, repo, token } = requireGitEnv();
-	const repoUrl = `${GITHUB_API_BASE_URL}/${owner}/${repo}/contents/til/${slug}.md`;
-	const res = await fetch(repoUrl, {
-		headers: { Authorization: `token ${token}` },
+	const url = `${GITHUB_API_BASE_URL}/${owner}/${repo}/contents/til/${slug}.md`;
+	const res = await fetch(url, {
+		headers: createAuthHeaders(token),
 		cache: 'no-cache',
 	});
 	if (res.status === 404) return null;


### PR DESCRIPTION
## 📝 작업 내용
### posting detail page 리팩토링
**타입 정의 통합**
- `Params`와 `Props` 타입을 모두 interface로 통일 ([TypeScript 공식 문서 권장사항 반영](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces))
<img width="600" height="198" alt="image" src="https://github.com/user-attachments/assets/48d8b221-6958-4fb5-ba4a-54c9e590d615" />

   - cf. 따로 개인 취향이 있다거나 컨벤션을 따로 지정하는게 좋다 생각하시면 말씀해주세요

**에러 처리**
- 바로 github api에서 파일을 페칭해오던 형태에서 GitHub 환경변수 설정 검증을 먼저 하고 데이터를 페칭해오기 위해 `requireGitEnv` 함수 추가
- `getMarkdownContent`에서 404 에러는 null을 반환하고 기타 오류는 throw하도록 분리

**코드 구조 개선**
- markdown 파싱 로직을 `getDetailPost` 함수로 분리하고, html 태그 self-closing 등의 정규식 처리를 간단화
- 가독성 개선을 위해 UI 컴포넌트(`PostTitle`, `PostContent`)를 별도 함수로 분리

**etc**
- [rehype-sanitize](https://github.com/rehypejs/rehype-sanitize) 라이브러리로 xss 방지
- 마크다운 원본 파일 내에서 이미 링크 처리가 되고 있기에 기존의 url 텍스트를 자동 링크로 변환하는 정규식은 제거

### posting page 리팩토링
#### template
- 기존에 postingTemplate 이라는 이름으로 관리되던 파일은 next.js에서 제공하는 template 기능을 사용한다기 보단, 컴포넌트 용도로만 사용되고 있었기에 PostingList로 이름을 바꾸고 posting의 component 하위 디렉토리에 위치하도록 위치 및 컴포넌트명을 변경했습니다.
#### Data Fetch
- detail page와 일반 page, template에서 각각 관리되던 github markdown file fetch 함수를 `lib/github.ts`에서 관리하도록 응집화 했습니다.
- 참고: 기존의 `lib/github.ts`에 적혀있던 페칭함수는 사용되지 않는 것 같아 제거했습니다.
### 남은 사항
- [ ] 서버 컴포넌트와 클라이언트 컴포넌트 hydrate 불일치 문제 해결하기 -> 현재는 상위에 use client를 명시해서 임시방편....
- [ ] search result 컴포넌트 width 수정

## 🙇 참고 사항
우선 posting/[slug] 페이지만 리팩토링 했는데,
해당 PR에서 추후 posting/page와 posting template까지 리팩토링 할 예정입니다
만약 더 잘개 쪼개는게 좋다고 생각하신다면 말씀해주세요